### PR TITLE
Add shuffle Demon Hunter Devourer spec support

### DIFF
--- a/BracketNames.lua
+++ b/BracketNames.lua
@@ -41,4 +41,5 @@ GSTBracketNames = {
   "shuffle_shaman_elemental",
   "shuffle_mage_arcane",
   "shuffle_warrior_protection",
+  "shuffle_demonhunter_devourer",
 };

--- a/src/build.ts
+++ b/src/build.ts
@@ -44,7 +44,8 @@ export type ShuffleLeaderBoardName =
   | "shuffle-druid-restoration"
   | "shuffle-shaman-elemental"
   | "shuffle-mage-arcane"
-  | "shuffle-warrior-protection";
+  | "shuffle-warrior-protection"
+  | "shuffle-demonhunter-devourer";
 
 export const shuffleSpecs: string[] = [
   "shuffle-warrior-fury",
@@ -86,6 +87,7 @@ export const shuffleSpecs: string[] = [
   "shuffle-shaman-elemental",
   "shuffle-mage-arcane",
   "shuffle-warrior-protection",
+  "shuffle-demonhunter-devourer",
 ];
 
 type RaidbotsEnchant = {


### PR DESCRIPTION
Added support for Demon Hunter Devourer spec in Solo Shuffle leaderboards. Registered the new spec in bracket names, TypeScript type definitions, and the shuffle specs list.