### PR TITLE
fix: enable all tooltip brackets by default

### DIFF
--- a/GearStick.lua
+++ b/GearStick.lua
@@ -182,6 +182,20 @@ function frame:OnEvent(event, arg1, arg2)
 		if GearStickSettings == nil then
 			GearStickSettings = {};
 		end
+		-- Apply defaults for any missing settings so all brackets show by default
+		local defaults = {
+			["2v2"] = true,
+			["3v3"] = true,
+			["pve"] = true,
+			["bis"] = false,
+			["debug"] = false,
+			["profiling"] = false,
+		}
+		for key, value in pairs(defaults) do
+			if GearStickSettings[key] == nil then
+				GearStickSettings[key] = value
+			end
+		end
 		local settingsEnd = debugprofilestop()
 		local settingsTime = settingsEnd - settingsStart
 
@@ -347,7 +361,14 @@ SlashCmdList.GST = function(arg1)
 	end
 	-- reset all options
 	if msg == "reset" then
-		GearStickSettings = {}
+		GearStickSettings = {
+			["2v2"] = true,
+			["3v3"] = true,
+			["pve"] = true,
+			["bis"] = false,
+			["debug"] = false,
+			["profiling"] = false,
+		}
 		GST_LogUser("Settings have been reset.")
 		return
 	end


### PR DESCRIPTION
## Summary
- **Root cause:** `GearStickSettings` was initialized as an empty table `{}` with no defaults. All tooltip bracket checks (`GearStickSettings["2v2"]`, `["3v3"]`, `["pve"]`) evaluated to `nil` (falsy), meaning no tooltips showed unless a user manually enabled each one via `/gst <bracket>` or the config UI.
- A user seeing only 3v3 tooltips had likely only toggled on 3v3 without realizing 2v2 and PvE needed separate activation.
- Added default settings (`2v2=true`, `3v3=true`, `pve=true`) applied on first load (when keys are `nil`) and on `/gst reset`. Existing users who explicitly disabled a bracket are unaffected since defaults only apply when the setting key is missing.

## Test plan
- [ ] Fresh install: verify all three tooltip brackets (2v2, 3v3, PvE) show on item tooltips without any manual setup
- [ ] Existing user who disabled 2v2: verify 2v2 stays disabled after updating (the `nil` check preserves explicit `false` values)
- [ ] `/gst reset`: verify all three brackets re-enable after reset
- [ ] `/gst status`: verify all default settings appear in status output

Munr-Job-ID: 594303e9536947a08bbaf5badb4d5854
Munr-Session-ID: 1f0a0c8e-gear-stick-tooltip-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)