### PR TITLE
fix: stabilize stat slug ordering for equal-value secondary stats

### DIFF
--- a/ItemUtils.lua
+++ b/ItemUtils.lua
@@ -104,8 +104,13 @@ end
 
 -- Concats a table of secondary stats into a slug
 function GST_ItemUtils.ReduceSecondariesTableToSlug(tbl)
-    -- Sort by value (highest first)
-    table.sort(tbl, function(a, b) return a.value > b.value end)
+    -- Sort by value (highest first), then alphabetically by type for stable ordering
+    table.sort(tbl, function(a, b)
+        if a.value ~= b.value then
+            return a.value > b.value
+        end
+        return a.type < b.type
+    end)
     -- debug(tbl)
 
     -- Build result string

--- a/src/build.ts
+++ b/src/build.ts
@@ -199,7 +199,11 @@ function getStatsTag(item: Histo, rename: boolean = true) {
   const stats = item.item.stats
     ? item.item.stats
         .filter((s) => secondaryStats.includes(s.type?.type))
-        .sort((a, b) => (b.value || 0) - (a.value || 0))
+        .sort((a, b) => {
+          const diff = (b.value || 0) - (a.value || 0);
+          if (diff !== 0) return diff;
+          return (a.type?.type || "").localeCompare(b.type?.type || "");
+        })
         .map((s) => (rename ? niceNameMap[s.type!.type] : s.type.type))
         .join("-")
     : "";


### PR DESCRIPTION
## Summary
- When two secondary stats have identical values (e.g. 500 Haste / 500 Crit), `table.sort` (Lua) and `Array.sort` (JS) do not guarantee a stable element order, causing stat slugs to differ between the build pipeline and the game client (e.g. `HASTE_RATING-CRIT_RATING` vs `CRIT_RATING-HASTE_RATING`), which breaks item lookups by `statsShort`.
- Adds an alphabetical tiebreaker on stat type name to both `ItemUtils.ReduceSecondariesTableToSlug` (client) and `getStatsTag` (build) so equal-valued stats always produce the same canonical slug: `CRIT_RATING` < `HASTE_RATING` < `MASTERY_RATING` < `VERSATILITY`.

## Test plan
- [ ] Verify items with two equal-value secondaries produce identical slugs from the build output and from the in-game tooltip parser
- [ ] Confirm gear rank lookups succeed for items that previously failed due to slug mismatch
- [ ] Rebuild data and spot-check `statsShort` fields in `SlotGear.lua` for items known to have equal secondary stat values


Made with [Cursor](https://cursor.com)